### PR TITLE
Add custom ErrorSource case

### DIFF
--- a/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
+++ b/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
@@ -14,19 +14,19 @@ struct MyLocalizedError: LocalizedError {
 
 struct MyBaseError: BaseError {
     let errorDescription = "This is a fake base error message for presenting to the user."
-    let source = ErrorSource.allCases.randomElement()!
+    let source = ErrorSource.invalidUserInput
 }
 
 struct MyFatalError: FatalError {
     let errorDescription = "This is a fake fatal error message for presenting to the user."
-    let source = ErrorSource.allCases.randomElement()!
+    let source = ErrorSource.internalInconsistency
 }
 
 struct MyHealableError: HealableError {
     private let retryClosure: () -> Void
 
     let errorDescription = "This is a fake healable error message for presenting to the user."
-    let source = ErrorSource.allCases.randomElement()!
+    let source = ErrorSource.custom(title: "This is a custom error source!")
 
     var healingOptions: [HealingOption] {
         let retryOption = HealingOption(style: .recommended, title: "Try Again", handler: retryClosure)

--- a/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
+++ b/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
@@ -87,6 +87,9 @@ extension AlertLogErrorHandler: ErrorHandler {
 
         case .externalSystemBehavedUnexpectedly:
             return LocalizedString("\(keyPrefix).EXTERNAL_SYSTEM_BEHAVED_UNEXPECTEDLY")
+
+        case let .custom(title):
+            return title
         }
     }
 

--- a/Frameworks/MungoHealer/Models/ErrorSource.swift
+++ b/Frameworks/MungoHealer/Models/ErrorSource.swift
@@ -6,9 +6,10 @@
 import Foundation
 
 /// A general classification between different sources for runtime errors.
-public enum ErrorSource: CaseIterable {
+public enum ErrorSource {
     case invalidUserInput
     case internalInconsistency
     case externalSystemUnavailable
     case externalSystemBehavedUnexpectedly
+    case custom(title: String)
 }


### PR DESCRIPTION
# Custom ErrorSource

This PR adds a custom case for the ErrorSource enum.

You can use this case as follows:
```swift
struct MyBaseError: BaseError {
    let errorDescription = "This is a fake base error message for presenting to the user."
    let source = ErrorSource.custom(title: "This is a custom error source title!")
}
```

However, a drawback of this implementation is that we have to drop the CaseIterable constraint from the ErrorSource enum. This results in the loss of `static var allCases` and so for the demo had to be adjusted. 
On the other hand, this will prevent a misuse of the framework and keeps all errors more concise and descriptive.
