### PR TITLE
Add debugDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Added
 - Convenience implementations of error protocols: `MungoError`, `MungoFatalError` & `MungoHealableError`
+- A `debugDescription` as an addition to the `BaseError` protocol.
 
 ## [0.1.0] - 2018-10-16
 ### Added

--- a/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
+++ b/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
@@ -36,7 +36,7 @@ public struct AlertLogErrorHandler {
 
 extension AlertLogErrorHandler: ErrorHandler {
     public func handle(error: Error) {
-        logError(error.localizedDescription)
+        log(error)
 
         if let localizedError = error as? LocalizedError, let errorDescription = localizedError.errorDescription {
             let alertTitle = LocalizedString("ALERT_LOG_ERROR_HANDLER.GENERIC_ERROR_TITLE")
@@ -47,7 +47,7 @@ extension AlertLogErrorHandler: ErrorHandler {
     }
 
     public func handle(baseError: BaseError) {
-        logError(baseError.localizedDescription)
+        log(baseError)
 
         let okayTitle = LocalizedString("ALERT_LOG_ERROR_HANDLER.OKAY_BUTTON.TITLE")
         let okayAlertAction = UIAlertAction(title: okayTitle, style: .default, handler: nil)
@@ -55,7 +55,7 @@ extension AlertLogErrorHandler: ErrorHandler {
     }
 
     public func handle(fatalError: FatalError) {
-        logError(fatalError.localizedDescription)
+        log(fatalError)
 
         let terminateTitle = LocalizedString("ALERT_LOG_ERROR_HANDLER.TERMINATE_BUTTON.TITLE")
         let terminateAlertAction = UIAlertAction(title: terminateTitle, style: .destructive) { _ in
@@ -66,7 +66,7 @@ extension AlertLogErrorHandler: ErrorHandler {
     }
 
     public func handle(healableError: HealableError) {
-        logError(healableError.localizedDescription)
+        log(healableError)
 
         let healingOptions = healableError.healingOptions.map { alertAction(healingOption: $0) }
         showAlert(title: title(for: healableError.source), message: healableError.localizedDescription, actions: healingOptions)
@@ -105,6 +105,14 @@ extension AlertLogErrorHandler: ErrorHandler {
         }()
 
         return UIAlertAction(title: healingOption.title, style: alertActionStyle) { _ in healingOption.handler() }
+    }
+
+    private func log(_ error: Error) {
+        if let baseError = error as? BaseError, let description = baseError.debugDescription, !description.isBlank {
+            logError(description)
+        } else {
+            logError(error.localizedDescription)
+        }
     }
 
     private func crash(message: String) { // swiftlint:disable:this unavailable_function

--- a/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
+++ b/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
@@ -108,8 +108,8 @@ extension AlertLogErrorHandler: ErrorHandler {
     }
 
     private func log(_ error: Error) {
-        if let baseError = error as? BaseError, let description = baseError.debugDescription, !description.isBlank {
-            logError(description)
+        if let baseError = error as? BaseError, let debugDescription = baseError.debugDescription, !debugDescription.isBlank {
+            logError("\(error.localizedDescription) | Details: \(debugDescription)")
         } else {
             logError(error.localizedDescription)
         }

--- a/Frameworks/MungoHealer/ErrorTypes/MungoError.swift
+++ b/Frameworks/MungoHealer/ErrorTypes/MungoError.swift
@@ -8,9 +8,11 @@ import Foundation
 public class MungoError: BaseError {
     public let source: ErrorSource
     public let errorDescription: String
+    public let debugDescription: String?
 
-    public init(source: ErrorSource, message: String) {
+    public init(source: ErrorSource, message: String, debugDescription: String? = nil) {
         self.source = source
         self.errorDescription = message
+        self.debugDescription = debugDescription
     }
 }

--- a/Frameworks/MungoHealer/ErrorsProtocols/BaseError.swift
+++ b/Frameworks/MungoHealer/ErrorsProtocols/BaseError.swift
@@ -15,10 +15,17 @@ public protocol BaseError: Error {
 
     /// A localized message describing what error occurred.
     var errorDescription: String { get }
+
+    /// A more concise description of the error for debugging purposes.
+    var debugDescription: String? { get }
 }
 
 extension BaseError {
     var localizedDescription: String {
+        return errorDescription
+    }
+
+    var debugDescription: String {
         return errorDescription
     }
 }

--- a/Frameworks/MungoHealer/ErrorsProtocols/BaseError.swift
+++ b/Frameworks/MungoHealer/ErrorsProtocols/BaseError.swift
@@ -24,8 +24,4 @@ extension BaseError {
     var localizedDescription: String {
         return errorDescription
     }
-
-    var debugDescription: String {
-        return errorDescription
-    }
 }

--- a/Frameworks/MungoHealer/Globals/Extensions/StringExtension.swift
+++ b/Frameworks/MungoHealer/Globals/Extensions/StringExtension.swift
@@ -7,8 +7,8 @@ import Foundation
 
 extension String {
     /// - Returns: `true` if contains any cahracters other than whitespace or newline characters, else `no`.
-    public var isBlank: Bool { return stripped().isEmpty }
+    var isBlank: Bool { return stripped().isEmpty }
 
     /// - Returns: The string stripped by whitespace and newline characters from beginning and end.
-    public func stripped() -> String { return trimmingCharacters(in: .whitespacesAndNewlines) }
+    func stripped() -> String { return trimmingCharacters(in: .whitespacesAndNewlines) }
 }

--- a/Frameworks/MungoHealer/Globals/Extensions/StringExtension.swift
+++ b/Frameworks/MungoHealer/Globals/Extensions/StringExtension.swift
@@ -1,0 +1,14 @@
+//
+//  Created by Niklas Bülow on 23.10.18.
+//  Copyright © 2018 Jamit Labs GmbH. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    /// - Returns: `true` if contains any cahracters other than whitespace or newline characters, else `no`.
+    public var isBlank: Bool { return stripped().isEmpty }
+
+    /// - Returns: The string stripped by whitespace and newline characters from beginning and end.
+    public func stripped() -> String { return trimmingCharacters(in: .whitespacesAndNewlines) }
+}

--- a/MungoHealer.xcodeproj/project.pbxproj
+++ b/MungoHealer.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		A102BDFF1F023E32000C6B38 /* MungoHealer.h in Headers */ = {isa = PBXBuildFile; fileRef = A102BDFE1F023E13000C6B38 /* MungoHealer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A102BE011F023E33000C6B38 /* MungoHealer.h in Headers */ = {isa = PBXBuildFile; fileRef = A102BDFE1F023E13000C6B38 /* MungoHealer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7D1B08D217F4B9E007C6F48 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7D1B08C217F4B9E007C6F48 /* StringExtension.swift */; };
+		F7D1B090217F5A8B007C6F48 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7D1B08C217F4B9E007C6F48 /* StringExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -701,6 +702,7 @@
 				825D651D2174D570007A3ED3 /* UIWindowExtension.swift in Sources */,
 				82C646EA21762B7F00A41245 /* MungoHealableError.swift in Sources */,
 				825D65192174D335007A3ED3 /* ErrorHandler.swift in Sources */,
+				F7D1B090217F5A8B007C6F48 /* StringExtension.swift in Sources */,
 				825D65162174D32A007A3ED3 /* AlertLogErrorHandler.swift in Sources */,
 				825D650D2174C5E5007A3ED3 /* HealableError.swift in Sources */,
 				825D650A2174C344007A3ED3 /* ErrorSource.swift in Sources */,

--- a/MungoHealer.xcodeproj/project.pbxproj
+++ b/MungoHealer.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		A102BDD41F023C81000C6B38 /* Quick.framework in Carthage */ = {isa = PBXBuildFile; fileRef = A102BDCA1F023C3E000C6B38 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A102BDFF1F023E32000C6B38 /* MungoHealer.h in Headers */ = {isa = PBXBuildFile; fileRef = A102BDFE1F023E13000C6B38 /* MungoHealer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A102BE011F023E33000C6B38 /* MungoHealer.h in Headers */ = {isa = PBXBuildFile; fileRef = A102BDFE1F023E13000C6B38 /* MungoHealer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7D1B08D217F4B9E007C6F48 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7D1B08C217F4B9E007C6F48 /* StringExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -132,6 +133,7 @@
 		A15AD1201F0240C9004D7ED3 /* MungoHealer.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = MungoHealer.podspec; sourceTree = "<group>"; };
 		A15AD1211F02447E004D7ED3 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		A15AD1241F0262D1004D7ED3 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		F7D1B08C217F4B9E007C6F48 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -199,6 +201,7 @@
 		825D651A2174D55A007A3ED3 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				F7D1B08C217F4B9E007C6F48 /* StringExtension.swift */,
 				825D651B2174D570007A3ED3 /* UIWindowExtension.swift */,
 			);
 			path = Extensions;
@@ -669,6 +672,7 @@
 				825D651C2174D570007A3ED3 /* UIWindowExtension.swift in Sources */,
 				82C646E921762B7F00A41245 /* MungoHealableError.swift in Sources */,
 				825D65182174D335007A3ED3 /* ErrorHandler.swift in Sources */,
+				F7D1B08D217F4B9E007C6F48 /* StringExtension.swift in Sources */,
 				825D65152174D32A007A3ED3 /* AlertLogErrorHandler.swift in Sources */,
 				825D650C2174C5E5007A3ED3 /* HealableError.swift in Sources */,
 				825D65092174C344007A3ED3 /* ErrorSource.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ The options are explained in detail [here](https://khawerkhaliq.com/blog/swift-e
 **`errorDescription: String`**
 A localized message describing what error occurred. This will be presented to the user as the alerts message by default when the error occurs.
 
+**`debugDescription: String?`**
+An optional message describing the error in more technical detail for debugging purposes. This will **not** be presented to the user and so for **only** logged.
+
 </details>
 
 <details>


### PR DESCRIPTION
# Add debugDescription

This PR introduces the variable `debugDescription` as an addition to the BaseError protocol.
The `debugDescription` allows developers to have a distinct debug description and a localized description of the error.

Advantages of this implementation are, that developers can have a more concise and descriptive description of the error for debugging purposes while hiding all technical details from the user.