### PR TITLE
Add custom ErrorSource case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Added
 - Convenience implementations of error protocols: `MungoError`, `MungoFatalError` & `MungoHealableError`
+- A custom `ErrorSource` case.
 
 ## [0.1.0] - 2018-10-16
 ### Added

--- a/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
+++ b/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
@@ -14,19 +14,19 @@ struct MyLocalizedError: LocalizedError {
 
 struct MyBaseError: BaseError {
     let errorDescription = "This is a fake base error message for presenting to the user."
-    let source = ErrorSource.allCases.randomElement()!
+    let source = ErrorSource.invalidUserInput
 }
 
 struct MyFatalError: FatalError {
     let errorDescription = "This is a fake fatal error message for presenting to the user."
-    let source = ErrorSource.allCases.randomElement()!
+    let source = ErrorSource.internalInconsistency
 }
 
 struct MyHealableError: HealableError {
     private let retryClosure: () -> Void
 
     let errorDescription = "This is a fake healable error message for presenting to the user."
-    let source = ErrorSource.allCases.randomElement()!
+    let source = ErrorSource.custom(title: "This is a custom error source!")
 
     var healingOptions: [HealingOption] {
         let retryOption = HealingOption(style: .recommended, title: "Try Again", handler: retryClosure)

--- a/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
+++ b/Frameworks/MungoHealer/ErrorHandlers/AlertLogErrorHandler.swift
@@ -87,6 +87,9 @@ extension AlertLogErrorHandler: ErrorHandler {
 
         case .externalSystemBehavedUnexpectedly:
             return LocalizedString("\(keyPrefix).EXTERNAL_SYSTEM_BEHAVED_UNEXPECTEDLY")
+
+        case let .custom(title):
+            return title
         }
     }
 

--- a/Frameworks/MungoHealer/Models/ErrorSource.swift
+++ b/Frameworks/MungoHealer/Models/ErrorSource.swift
@@ -6,9 +6,10 @@
 import Foundation
 
 /// A general classification between different sources for runtime errors.
-public enum ErrorSource: CaseIterable {
+public enum ErrorSource {
     case invalidUserInput
     case internalInconsistency
     case externalSystemUnavailable
     case externalSystemBehavedUnexpectedly
+    case custom(title: String)
 }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A classification of the errors source. MungoHealer will automatically provide an
 -  `.internalInconsistency`
 -  `.externalSystemUnavailable`
 -  `.externalSystemBehavedUnexpectedlyBased`
+-  `.custom(title: String)`
 
 The options are explained in detail [here](https://khawerkhaliq.com/blog/swift-error-handling/#Sources_of_errors).
 


### PR DESCRIPTION
This PR adds a custom case for the ErrorSource enum.

You can use this case as follows:

```swift
struct MyBaseError: BaseError {
    let errorDescription = "This is a fake base error message for presenting to the user."
    let source = ErrorSource.custom(title: "This is a custom error source title!")
}
```

However, a drawback of this implementation is that we have to drop the CaseIterable constraint from the ErrorSource enum. This results in the loss of static var allCases and so for the demo had to be adjusted.
On the other hand, this will prevent a misuse of the framework and keeps all errors more concise and descriptive.