### PR TITLE
Migrating to Swift 5

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.3.1"
-github "Quick/Quick" "v1.3.2"
+github "Quick/Nimble" "v8.0.1"
+github "Quick/Quick" "v2.1.0"

--- a/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo.xcodeproj/project.pbxproj
+++ b/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 				TargetAttributes = {
 					825D64ED2174BD61007A3ED3 = {
 						CreatedOnToolsVersion = 10.0;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -303,7 +304,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jamitlabs.MungoHealer-iOS-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -321,7 +322,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jamitlabs.MungoHealer-iOS-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
+++ b/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
@@ -13,16 +13,22 @@ struct MyLocalizedError: LocalizedError {
 }
 
 struct MyBaseError: BaseError {
+    var debugDescription: String?
+    
     let errorDescription = "This is a fake base error message for presenting to the user."
     let source = ErrorSource.allCases.randomElement()!
 }
 
 struct MyFatalError: FatalError {
+    var debugDescription: String?
+    
     let errorDescription = "This is a fake fatal error message for presenting to the user."
     let source = ErrorSource.allCases.randomElement()!
 }
 
 struct MyHealableError: HealableError {
+    var debugDescription: String?
+    
     private let retryClosure: () -> Void
 
     let errorDescription = "This is a fake healable error message for presenting to the user."

--- a/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
+++ b/Demos/MungoHealer iOS-Demo/MungoHealer iOS-Demo/ViewController.swift
@@ -13,22 +13,16 @@ struct MyLocalizedError: LocalizedError {
 }
 
 struct MyBaseError: BaseError {
-    var debugDescription: String?
-    
     let errorDescription = "This is a fake base error message for presenting to the user."
     let source = ErrorSource.allCases.randomElement()!
 }
 
 struct MyFatalError: FatalError {
-    var debugDescription: String?
-    
     let errorDescription = "This is a fake fatal error message for presenting to the user."
     let source = ErrorSource.allCases.randomElement()!
 }
 
 struct MyHealableError: HealableError {
-    var debugDescription: String?
-    
     private let retryClosure: () -> Void
 
     let errorDescription = "This is a fake healable error message for presenting to the user."

--- a/Frameworks/MungoHealer/ErrorsProtocols/BaseError.swift
+++ b/Frameworks/MungoHealer/ErrorsProtocols/BaseError.swift
@@ -24,4 +24,6 @@ extension BaseError {
     var localizedDescription: String {
         return errorDescription
     }
+
+    public var debugDescription: String? { return nil }
 }

--- a/MungoHealer.xcodeproj/project.pbxproj
+++ b/MungoHealer.xcodeproj/project.pbxproj
@@ -528,17 +528,17 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Jamit Labs GmbH";
 				TargetAttributes = {
 					A102BD3D1F02355A000C6B38 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					A102BD461F02355A000C6B38 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					A102BD781F023582000C6B38 = {
@@ -908,6 +908,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -929,6 +930,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -945,6 +947,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jamitlabs.$(TARGET_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -961,6 +964,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jamitlabs.$(TARGET_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/MungoHealer.xcodeproj/xcshareddata/xcschemes/MungoHealer iOS.xcscheme
+++ b/MungoHealer.xcodeproj/xcshareddata/xcschemes/MungoHealer iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MungoHealer.xcodeproj/xcshareddata/xcschemes/MungoHealer tvOS.xcscheme
+++ b/MungoHealer.xcodeproj/xcshareddata/xcschemes/MungoHealer tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
         <img src="https://img.shields.io/badge/Version-0.3.2-blue.svg"
              alt="Version: 0.3.2">
     </a>
-    <img src="https://img.shields.io/badge/Swift-4.2-FFAC45.svg"
-         alt="Swift: 4.2">
+    <img src="https://img.shields.io/badge/Swift-5.0-FFAC45.svg"
+         alt="Swift: 5.0">
     <img src="https://img.shields.io/badge/Platforms-iOS%20%7C%20tvOS-FF69B4.svg"
         alt="Platforms: iOS | tvOS">
     <a href="https://github.com/JamitLabs/MungoHealer/blob/stable/LICENSE">


### PR DESCRIPTION
Following updates have been done for Swift 5 compatibility:
- Migrate framework and demo project to Swift 5
- Upgrade 3rd-party frameworks
- Update badge in `README`